### PR TITLE
Fixed a couple issues in the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
 		<dependency>
 			<groupId>be.maximvdw</groupId>
 			<artifactId>MVdWUpdater</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.6.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot</artifactId>
-			<version>1.9</version>
+			<version>1.12.2-R0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
1. The MVdWUpdater version 1.0.2 does not exist in the repo and so was changed to the newest 1.6.0.

2. The spigot version 1.9 does not exist and so was changed to the newest 1.12.2 snapshot.

These were changed because developers trying to use the maven would have their projects try and install these two files which do not even exist.