### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
 			<id>bstats-repo</id>
 			<url>http://repo.bstats.org/content/repositories/releases/</url>
 		</repository>
+		<repository>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+		</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -30,8 +34,9 @@
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot</artifactId>
-			<version>1.9</version>
+			<artifactId>spigot-api</artifactId>
+			<version>1.9-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.bstats</groupId>


### PR DESCRIPTION
Instead of relying on the BuildTools-only spigot artifact, we now rely on the publicly available spigot-api artifact. This is possible, since the API does not make use of any CraftBukkit or NMS code or any other code that is exclusively provided by the spigot artifact. The scope is also set to provided, so the artifact isn't needlessly shaded into the final jar. This change will help developers who want to make use of this API by ensuring the artifact can be fetched online, without having the run BuildTools first. Compatibility is still ensured, since the minimum version is still at 1.9.

This differs from pull request #6 since it doesn't require you to drop versions 1.9-1.11. That being said only this pull request or pull request #6 should be merged. The other one should be closed, since the main issue (Apache Maven being unable to find the non-existent local artifact) will be fixed by merging either pull request.