### PR TITLE
Add exclusion for Spigot.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
 			<groupId>be.maximvdw</groupId>
 			<artifactId>MVdWUpdater</artifactId>
 			<version>1.6.0-SNAPSHOT</version>
+			<exclusions>
+                		<exclusion>
+                    			<groupId>org.spigotmc</groupId>
+                    			<artifactId>spigot</artifactId>
+               			 </exclusion>
+            		</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>net.md-5</groupId>


### PR DESCRIPTION
This will allow downstream project to avoid requiring the spigot:1.9 jar to complete a build
Fix #13 